### PR TITLE
Rename RSSlink to RSSLink

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -12,5 +12,5 @@
 
     <link href="//fonts.googleapis.com/css?family=PT+Serif" rel="stylesheet" type="text/css">
     <link rel="stylesheet" href="{{ .Site.BaseURL }}/css/application.css">
-    <link href="{{ .RSSlink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
+    <link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
   </head>


### PR DESCRIPTION
The former will be deprecated and eventually removed from Hugo.

Note: Currently both of them exist in Hugo, which is the reason for the cleanup.